### PR TITLE
update spree reference. no longer reference specific minor version; allo...

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,10 @@ gem 'spree', github: 'godaddy/spree', branch: '2-2-nemo-stable'
 gem 'spree_auth_devise', github: 'spree/spree_auth_devise', :branch => '2-2-stable'
 
 group :test do
-  gem 'rails', '4.0.9' #Temporary version lock to 4.0.9 to avoid bad rails version.
+  gem 'rails'
+  gem 'rspec'
   gem 'rspec-rails', '~> 2.0'
+  gem 'sass-rails'
   gem 'simplecov-rcov'
   gem 'yarjuf'
   gem 'require_all'
@@ -13,6 +15,7 @@ group :test do
   gem 'poltergeist'
   gem 'sqlite3'
   gem 'byebug'
+  gem 'launchy'
 end
 
 gemspec

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Behind-the-scenes, this extension uses [PayPal's Merchant Ruby SDK](https://gith
 
 1. Add this extension to your Gemfile with this line:
 
-        gem 'spree_paypal_express', :github => "radar/better_spree_paypal_express", :branch => "2-2-stable"
+        gem 'spree_paypal_express', :github => "spree-contrib/better_spree_paypal_express", :branch => "2-2-stable"
 
 2. Install the gem using Bundler:
 
@@ -122,7 +122,7 @@ Starting point:
 * Ensure specs pass by running `bundle exec rspec spec`
 * Submit your pull request
 
-Copyright (c) 2013 Spree Commerce and contributors, released under the [New BSD License][3]
+Copyright (c) 2014 Spree Commerce and contributors, released under the [New BSD License][3]
 
 [1]: http://www.fsf.org/licensing/essays/free-sw.html
 [2]: https://github.com/spree/better_spree_paypal_express/issues

--- a/app/assets/javascripts/spree/frontend/spree_paypal_express.js
+++ b/app/assets/javascripts/spree/frontend/spree_paypal_express.js
@@ -2,18 +2,20 @@
 
 SpreePaypalExpress = {
   hidePaymentSaveAndContinueButton: function(paymentMethod) {
-    if (SpreePaypalExpress.paymentMethodID && paymentMethod.val() == SpreePaypalExpress.paymentMethodID) {
+    if (!$('#use_existing_card_yes:checked').length && SpreePaypalExpress.paymentMethodID && paymentMethod.val() == SpreePaypalExpress.paymentMethodID) {
       $('.continue').hide();
     } else {
       $('.continue').show();
     }
+  },
+  checkedPaymentMethod: function() {
+    return $('div[data-hook="checkout_payment_step"] input[type="radio"][name="order[payments_attributes][][payment_method_id]"]:checked');
   }
 }
 
 $(document).ready(function() {
-  checkedPaymentMethod = $('div[data-hook="checkout_payment_step"] input[type="radio"]:checked');
-  SpreePaypalExpress.hidePaymentSaveAndContinueButton(checkedPaymentMethod);
+  SpreePaypalExpress.hidePaymentSaveAndContinueButton(SpreePaypalExpress.checkedPaymentMethod());
   paymentMethods = $('div[data-hook="checkout_payment_step"] input[type="radio"]').click(function (e) {
-    SpreePaypalExpress.hidePaymentSaveAndContinueButton($(e.target));
+    SpreePaypalExpress.hidePaymentSaveAndContinueButton(SpreePaypalExpress.checkedPaymentMethod());
   });
 })

--- a/app/assets/javascripts/spree/frontend/spree_paypal_express.js
+++ b/app/assets/javascripts/spree/frontend/spree_paypal_express.js
@@ -1,21 +1,31 @@
 //= require spree/frontend
 
 SpreePaypalExpress = {
-  hidePaymentSaveAndContinueButton: function(paymentMethod) {
-    if (!$('#use_existing_card_yes:checked').length && SpreePaypalExpress.paymentMethodID && paymentMethod.val() == SpreePaypalExpress.paymentMethodID) {
-      $('.continue').hide();
+  updateSaveAndContinueVisibility: function() {
+    if (this.isButtonHidden()) {
+      $(this).trigger('hideSaveAndContinue')
     } else {
-      $('.continue').show();
+      $(this).trigger('showSaveAndContinue')
     }
+  },
+  isButtonHidden: function () {
+    paymentMethod = this.checkedPaymentMethod();
+    return (!$('#use_existing_card_yes:checked').length && SpreePaypalExpress.paymentMethodID && paymentMethod.val() == SpreePaypalExpress.paymentMethodID);
   },
   checkedPaymentMethod: function() {
     return $('div[data-hook="checkout_payment_step"] input[type="radio"][name="order[payments_attributes][][payment_method_id]"]:checked');
+  },
+  hideSaveAndContinue: function() {
+    $('.continue').hide();
+  },
+  showSaveAndContinue: function() {
+    $('.continue').show();
   }
 }
 
 $(document).ready(function() {
-  SpreePaypalExpress.hidePaymentSaveAndContinueButton(SpreePaypalExpress.checkedPaymentMethod());
+  SpreePaypalExpress.updateSaveAndContinueVisibility();
   paymentMethods = $('div[data-hook="checkout_payment_step"] input[type="radio"]').click(function (e) {
-    SpreePaypalExpress.hidePaymentSaveAndContinueButton(SpreePaypalExpress.checkedPaymentMethod());
+    SpreePaypalExpress.updateSaveAndContinueVisibility();
   });
 })

--- a/app/controllers/spree/paypal_controller.rb
+++ b/app/controllers/spree/paypal_controller.rb
@@ -6,10 +6,11 @@ module Spree
       order = current_order || raise(ActiveRecord::RecordNotFound)
       items = order.line_items.map(&method(:line_item))
 
-      tax_adjustments = order.all_adjustments.tax.additional
-      shipping_adjustments = order.all_adjustments.shipping
+      additional_adjustments = order.all_adjustments.additional
+      tax_adjustments = additional_adjustments.tax
+      shipping_adjustments = additional_adjustments.shipping
 
-      order.all_adjustments.eligible.each do |adjustment|
+      additional_adjustments.eligible.each do |adjustment|
         next if (tax_adjustments + shipping_adjustments).include?(adjustment)
         items << {
           :Name => adjustment.label,

--- a/app/controllers/spree/paypal_controller.rb
+++ b/app/controllers/spree/paypal_controller.rb
@@ -56,6 +56,7 @@ module Spree
       if order.complete?
         flash.notice = Spree.t(:order_processed_successfully)
         flash[:commerce_tracking] = "nothing special"
+        session[:order_id] = nil
         redirect_to completion_route(order)
       else
         redirect_to checkout_state_path(order.state)

--- a/app/controllers/spree/paypal_controller.rb
+++ b/app/controllers/spree/paypal_controller.rb
@@ -1,5 +1,7 @@
 module Spree
   class PaypalController < StoreController
+    ssl_allowed
+
     def express
       order = current_order || raise(ActiveRecord::RecordNotFound)
       items = order.line_items.map(&method(:line_item))

--- a/app/controllers/spree/paypal_controller.rb
+++ b/app/controllers/spree/paypal_controller.rb
@@ -92,6 +92,7 @@ module Spree
           :SolutionType => payment_method.preferred_solution.present? ? payment_method.preferred_solution : "Mark",
           :LandingPage => payment_method.preferred_landing_page.present? ? payment_method.preferred_landing_page : "Billing",
           :cppheaderimage => payment_method.preferred_logourl.present? ? payment_method.preferred_logourl : "",
+          :NoShipping => 1,
           :PaymentDetails => [payment_details(items)]
       }}
     end

--- a/spec/features/paypal_spec.rb
+++ b/spec/features/paypal_spec.rb
@@ -87,6 +87,43 @@ describe "PayPal", :js => true do
     end
   end
 
+  context "line item adjustments" do
+    let(:promotion) { Spree::Promotion.create(name: "10% off") }
+    before do
+      calculator = Spree::Calculator::FlatPercentItemTotal.new(preferred_flat_percent: 10)
+      action = Spree::Promotion::Actions::CreateItemAdjustments.create(:calculator => calculator)
+      promotion.actions << action
+    end    
+
+    it "includes line item adjustments in PayPal summary" do
+
+      visit spree.root_path
+      click_link 'iPad'
+      click_button 'Add To Cart'
+      # TODO: Is there a better way to find this current order?
+      order = Spree::Order.last
+      order.line_item_adjustments.count.should == 1
+
+      visit '/cart'
+      within("#cart_adjustments") do
+        page.should have_content("10% off")
+      end
+      click_button 'Checkout'
+      within("#guest_checkout") do
+        fill_in "Email", :with => "test@example.com"
+        click_button 'Continue'
+      end
+      fill_in_billing
+      click_button "Save and Continue"
+      # Delivery step doesn't require any action
+      click_button "Save and Continue"
+      find("#paypal_button").click
+      within("#miniCart") do
+        page.should have_content("10% off")
+      end
+    end
+  end
+
   # Regression test for #10
   context "will skip $0 items" do
     let!(:product2) { FactoryGirl.create(:product, :name => 'iPod') }

--- a/spree_paypal_express.gemspec
+++ b/spree_paypal_express.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency 'spree_core', '~> 2.2.7.0'
+  s.add_dependency 'spree_core', '~> 2.2.0'
   s.add_dependency 'paypal-sdk-merchant', '1.106.1'
 
   s.add_development_dependency 'capybara', '~> 2.1'

--- a/spree_paypal_express.gemspec
+++ b/spree_paypal_express.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency 'spree_core', '~> 2.2.0.beta'
+  s.add_dependency 'spree_core', '~> 2.2.0'
   s.add_dependency 'paypal-sdk-merchant', '1.106.1'
 
   s.add_development_dependency 'capybara', '~> 2.1'

--- a/spree_paypal_express.gemspec
+++ b/spree_paypal_express.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'factory_girl', '~> 4.2'
   s.add_development_dependency 'ffaker'
   s.add_development_dependency 'rspec-rails',  '~> 2.13'
-  s.add_development_dependency 'sass-rails'
+  s.add_development_dependency 'sass-rails', '~> 4.0.2'
   s.add_development_dependency 'selenium-webdriver'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'pry'


### PR DESCRIPTION
remove explicit version pinning from gemspec. gemfile and hosting app will take care of that detail. gemspec simply states it requires spree 2.2 variant
