### PR TITLE
NEMO-3587 Display error message when PayPal payment fails

### DIFF
--- a/app/controllers/spree/paypal_controller.rb
+++ b/app/controllers/spree/paypal_controller.rb
@@ -62,6 +62,7 @@ module Spree
         session[:order_id] = nil
         redirect_to completion_route(order)
       else
+        flash[:error] = Spree.t("paypal.order_not_completed")
         redirect_to checkout_state_path(order.state)
       end
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,6 +11,7 @@ en:
       token: "Token"
       refund: "Refund"
       refund_amount: "Amount"
+      order_not_completed: "We couldn't process your payment. Please try again or contact us if you continue to experience issues."
       original_amount: "Original amount: %{amount}"
       refund_successful: "PayPal refund successful"
       refund_unsuccessful: "PayPal refund unsuccessful"


### PR DESCRIPTION
![screen shot 2015-01-23 at 10 15 34 am](https://cloud.githubusercontent.com/assets/6935952/5880979/a3e5e660-a2f1-11e4-9ef8-e14649532ef9.png)

Are tests necessary?
