### PR TITLE
NEMO-6109 expose a global ButtonSource setting to pass BN Code with payments

### DIFF
--- a/app/models/spree/gateway/pay_pal_express.rb
+++ b/app/models/spree/gateway/pay_pal_express.rb
@@ -11,6 +11,8 @@ module Spree
     preference :landing_page, :string, default: 'Billing'
     preference :logourl, :string, default: ''
 
+    cattr_accessor :button_source
+
     def supports?(source)
       true
     end
@@ -60,7 +62,10 @@ module Spree
           :PaymentAction => "Sale",
           :Token => express_checkout.token,
           :PayerID => express_checkout.payer_id,
-          :PaymentDetails => pp_details_response.get_express_checkout_details_response_details.PaymentDetails
+          :PaymentDetails => pp_details_response.get_express_checkout_details_response_details.PaymentDetails,
+          # set ButtonSource for partner indicator: https://www.paypal-marketing.com/emarketing/partner/na/portal/integrate_bn_codes.html#ec
+          # if not set, ButtonSource defaults to "PayPal_SDK" in the PayPal SDK library
+          :ButtonSource => button_source
         }
       })
 


### PR DESCRIPTION
PayPal SDK will automatically default the "ButtonSource" attribute of an express checkout payment request to "PayPal_SDK". We need to set a partner code on this attribute for all payments, regardless of specific merchant. I tried to keep this simple by just exposing a class attribute on the model, which can be set by the application, since the attribute is effectively global and static. 
If the hosting application does not set this value, the underlying PayPal SDK will still set it to its default value, so this is a non-functional change for an app that doesn't set the value.
